### PR TITLE
Fix URL in package commentary

### DIFF
--- a/osx-plist.el
+++ b/osx-plist.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Neil Okamoto <neil.okamoto+melpa@gmail.com>
 ;; Keywords: convenience
 ;; Package-Requires: ((emacs "25.1"))
-;; URL: https://github.com/gonewest818/osx-plist.el
+;; URL: https://github.com/gonewest818/osx-plist
 ;; Version: 2.0.0
 
 ;; This file is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Correct the URL in the package's commentary.

* `osx-plist.el`: Fix URL in commentary.